### PR TITLE
uplevel subsection

### DIFF
--- a/src/b3.1/source/02_interface.rst
+++ b/src/b3.1/source/02_interface.rst
@@ -162,7 +162,7 @@ machines are forced into an initial state. The INTERCON connects the
 [RST_O] output to the [RST_I] input on MASTER and SLAVE interfaces.
 
 Signals Common to MASTER and SLAVE Interfaces
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`````````````````````````````````````````````
 
 **CLK_I**
 


### PR DESCRIPTION
"Signals Common to MASTER and SLAVE Interfaces" subsection has no number.

```
2.2 WISHBONE Signal Description
  2.2.1 SYSCON Module Signals
  - Signals Common to MASTER and SLAVE Interfaces
  2.2.2 MASTER Signals
  2.2.3 SLAVE Signals
```
It should probably be at the same level as:

```
2.2 WISHBONE Signal Description
  2.2.1 SYSCON Module Signals
  2.2.2 Signals Common to MASTER and SLAVE Interfaces
  2.2.3 MASTER Signals
  2.2.4 SLAVE Signals
```
