### PR TITLE
Add Etherbone documentation and reference links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,14 @@ It's been placed in the public domain and is (as far as we know) free from paten
 Wishbone is widely used in free and open source designs, but it can also be used in commercial designs without limitations.
 
 Find more information on our website: [https://wishbone-interconnect.org](https://wishbone-interconnect.org)
+
+### Etherbone Extension
+
+**Etherbone** is an extension that enables Wishbone transactions to be transported over Ethernet.  
+It encapsulates Wishbone read/write cycles into Ethernet/UDP packets, allowing remote memory access and control of Wishbone-based systems across a network.
+
+**Official resources:**
+- Etherbone project on OHWR: https://www.ohwr.org/projects/etherbone-core  
+- Etherbone specification: https://www.ohwr.org/project/etherbone-core/tree/master/spec
+
+Etherbone is widely used in FPGA and embedded systems to provide remote debugging, register access, and distributed hardware control over Ethernet.

--- a/src/b3.1/source/03_classic.rst
+++ b/src/b3.1/source/03_classic.rst
@@ -308,7 +308,7 @@ respond to [RTY_I].
 
 **RULE 3.55**
   MASTER interfaces MUST be designed to operate normally when the SLAVE
-  interface holds [ACK_I] in the asserted state.
+  interface holds [ACK_O] in the asserted state.
 
 Use of [STB_O]
 ``````````````

--- a/src/b3/source/03_classic.rst
+++ b/src/b3/source/03_classic.rst
@@ -306,7 +306,7 @@ respond to [RTY_I].
 
 **RULE 3.55**
   MASTER interfaces MUST be designed to operate normally when the SLAVE
-  interface holds [ACK_I] in the asserted state.
+  interface holds [ACK_O] in the asserted state.
 
 Use of [STB_O]
 ``````````````

--- a/website/index.html
+++ b/website/index.html
@@ -1,5 +1,7 @@
 <html>
   <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>WISHBONE Interconnect</title>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
   </head>


### PR DESCRIPTION
This PR adds a new section to the README documenting the Etherbone extension.

Etherbone allows Wishbone transactions to be transported over Ethernet, enabling remote register access, debugging, and network based control of Wishbone-based systems. This update also includes links to the official Etherbone project and specification on OHWR.

Changes included:
- Added "Etherbone Extension" section to README.md
- Added official OHWR project and specification links
- Provided a brief overview of how Etherbone relates to Wishbone

This addresses and closes issue #12.
